### PR TITLE
Add storage_options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Teleport has multiple [roles](http://gravitational.com/teleport/docs/architectur
   * [`teleport`](#teleport): Installs and configured teleport in your environment
 
 #### Private Classes
-  * [`teleport::install`]: Downloads the teleport binary and installs it in your env 
+  * [`teleport::install`]: Downloads the teleport binary and installs it in your env
   * [`teleport::config`]: Configure the service and the teleport config file
-  * [`teleport::service`]: Manage the teleport service 
-  
+  * [`teleport::service`]: Manage the teleport service
+
 
 ### `teleport`
 
@@ -129,7 +129,11 @@ When running in NAT'd environments, designates an IP for teleport to advertise.
 
 ##### `storage_backend` [String]
 
-Which storage backend to use. 
+Which storage backend to use.
+
+##### `storage_options` [String]
+
+Extra options for some storage backends, like DynamoDB.
 
 ##### `max_connections` [String]
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@
 #  Where to sylink the teleport web assets
 #
 # [*nodename*]
-#  Teleport nodename. 
+#  Teleport nodename.
 #  Defaults to $::fqdn fact
 #
 # [*data_dir*]
@@ -41,6 +41,10 @@
 #  Which storage backend to use.
 #  Defaults to undef (meaning teleport uses its
 #  default of boltdb
+#
+# [*storage_options*]
+#  Extra options for some storage backends, like DynamoDB.
+#  Defaults to {}
 #
 # [*max_connections*]
 #  Configure max connections for teleport
@@ -143,6 +147,7 @@ class teleport (
   $auth_token            = undef,
   $advertise_ip          = undef,
   $storage_backend       = undef,
+  $storage_options       = {},
   $max_connections       = 1000,
   $max_users             = 250,
   $log_dest              = 'stderr',
@@ -190,5 +195,3 @@ class teleport (
   anchor { 'teleport_final': }
 
 }
-
-

--- a/templates/teleport.yaml.erb
+++ b/templates/teleport.yaml.erb
@@ -9,7 +9,7 @@ teleport:
   nodename: <%= scope.lookupvar('teleport::nodename') %>
 
 <% if ![:undef, nil].include?(scope.lookupvar("teleport::data_dir")) -%>
-  # Data directory where Teleport keeps its data, like keys/users for 
+  # Data directory where Teleport keeps its data, like keys/users for
   # authentication (if using the default BoltDB back-end)
   data_dir: <%= scope.lookupvar('teleport::data_dir') -%>
 <% end -%>
@@ -39,7 +39,7 @@ teleport:
     max_connections: <%= scope.lookupvar('teleport::max_connections') %>
     max_users: <%= scope.lookupvar('teleport::max_users') %>
 
-  # Logging configuration. Possible output values are 'stdout', 'stderr' and 
+  # Logging configuration. Possible output values are 'stdout', 'stderr' and
   # 'syslog'. Possible severity values are INFO, WARN and ERROR (default).
   log:
     output: <%= scope.lookupvar('teleport::log_dest') %>
@@ -47,9 +47,12 @@ teleport:
 
 <% if ![:undef, nil].include?(scope.lookupvar("teleport::storage_backend")) -%>
   # Type of storage used for keys. You need to configure this to use etcd
-  # backend if you want to run Teleport in HA configuration.  
-  storage: 
+  # backend if you want to run Teleport in HA configuration.
+  storage:
     type: <%= scope.lookupvar('teleport::storage_backend') %>
+<% scope.lookupvar('teleport::storage_options').sort.each do |key,value| -%>
+    <%= key %>: <%= value %>
+<% end -%>
 <% end -%>
 
 # This section configures the 'auth service':


### PR DESCRIPTION
The DynamoDB storage backend requires some extra options in the `storage` section.
See https://gravitational.com/teleport/docs/2.3/admin-guide/#using-dynamodb